### PR TITLE
Fix links on the summer of pride page

### DIFF
--- a/summerofpride/index.html
+++ b/summerofpride/index.html
@@ -62,16 +62,16 @@
               <a class="nav-link" href="index.html">Home <span class="sr-only">(current)</span></a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="works.html">Works</a>
+              <a class="nav-link" href="/works.html">Works</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="http://wearemidboss.tumblr.com/" target="_blank">Blog</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="/about.html">About</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="contact.html">Contact</a>
+              <a class="nav-link" href="/contact.html">Contact</a>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
After playing ROM 2064 (great inclusive game, by the way), I found some non working links on the summer of pride page, with a github error message. A quick google search later, and here is the fix. 

(PS: Can't wait to go hunt the Golden Butterfly)